### PR TITLE
fix(docs): add missing comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this plugin as a dependency to `telescope.nvim`, like this:
     "nvim-telescope/telescope.nvim"
     dependencies = {
         {
-            "isak102/telescope-git-file-history.nvim"
+            "isak102/telescope-git-file-history.nvim",
             dependencies = { "tpope/vim-fugitive" }
         }
     }


### PR DESCRIPTION
I just copy and pasted your example lazy config and noticed it had a syntax error because it was missing a comma. This fixes that.