### PR TITLE
fix(docs): incorrect lua example for Lazy installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are a few key differences between this plugin and `:Telescope git_bcommits
 Add this plugin as a dependency to `telescope.nvim`, like this:
 ```lua
 {
-    "nvim-telescope/telescope.nvim"
+    "nvim-telescope/telescope.nvim",
     dependencies = {
         {
             "isak102/telescope-git-file-history.nvim",


### PR DESCRIPTION
The README contains code to install the plugin using the Lazy package manager.
The code contains a minor syntax error and will cause an invalid configuration error.